### PR TITLE
refactor: remove unused FLIP controller types

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,20 +1,6 @@
 /**
  * Глобальные объявления типов для портфолио
- * Использует экспортированные типы из FLIP контроллера
  */
-
-// Импортируем типы из FLIP контроллера
-import type { IFlipAnimationController, ElementRect, ElementBackground } from '../utils/flipController.js';
-
-// Конфигурация FLIP анимаций
-interface FlipConfig {
-  DURATION: number;
-  EASING: string;
-  ELASTIC_EASING: string;
-  Z_INDEX: number;
-  SCALE_FACTOR: number;
-  BLUR_AMOUNT: number;
-}
 
 // Данные портфолио
 interface PortfolioProject {
@@ -33,26 +19,9 @@ interface PortfolioProject {
   }>;
 }
 
-// Утилиты для FLIP анимаций
-interface FlipUtils {
-  forceRestoreElement(element: HTMLElement): void;
-}
-
 // Расширение глобального объекта Window
 declare global {
   interface Window {
-    // Конфигурация FLIP анимаций
-    FLIP_CONFIG: FlipConfig;
-    
-    // Конструктор FLIP контроллера
-    FlipAnimationController: new () => IFlipAnimationController;
-    
-    // Глобальный экземпляр контроллера
-    globalFlipController: IFlipAnimationController;
-    
-    // Утилиты для FLIP анимаций
-    flipUtils: FlipUtils;
-    
     // Данные портфолио
     portfolioProjects: PortfolioProject[];
   }


### PR DESCRIPTION
## Summary
- remove unused FLIP controller import and global fields

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68ad5ab34a548327a644e37ea45d5180