### PR TITLE
Use custom logger for ProgressiveImage force init

### DIFF
--- a/src/components/ProgressiveImage.astro
+++ b/src/components/ProgressiveImage.astro
@@ -95,9 +95,20 @@ const animationClass = `animate-${animationType}`;
     },
     
     forceInitialize() {
-      console.log('Принудительная инициализация изображения');
-      this.makeVisible();
-      this.setupImageHandlers();
+      try {
+        window.appLogger?.info('Принудительная инициализация изображения');
+        this.makeVisible();
+        this.setupImageHandlers();
+      } catch (error) {
+        window.appLogger?.error('Ошибка принудительной инициализации изображения', error);
+        if (window.errorHandler) {
+          window.errorHandler.handleError(error, {
+            type: 'image_force_init',
+            imageId: this.imageId,
+            element: this.$el
+          });
+        }
+      }
     },
     
     makeVisible() {
@@ -325,3 +336,8 @@ const animationClass = `animate-${animationType}`;
     </div>
   </div>
 </div>
+
+<script type="module">
+  import logger from '../utils/logger';
+  window.appLogger = logger;
+</script>

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,27 @@
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+interface Logger {
+  debug: (...args: any[]) => void;
+  info: (...args: any[]) => void;
+  warn: (...args: any[]) => void;
+  error: (...args: any[]) => void;
+}
+
+const logger: Logger = {
+  debug: (...args: any[]) => {
+    if (import.meta.env.DEV) {
+      console.debug(...args);
+    }
+  },
+  info: (...args: any[]) => {
+    console.info(...args);
+  },
+  warn: (...args: any[]) => {
+    console.warn(...args);
+  },
+  error: (...args: any[]) => {
+    console.error(...args);
+  }
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- replace `console.log` in ProgressiveImage with a custom logger and wrap `forceInitialize` in error handling
- add small logger utility with log level helpers and expose it globally for components

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad5d41235883278a23114e83e4fc22