### PR TITLE
test: add component tests

### DIFF
--- a/src/components/__tests__/ProgressiveImage.test.ts
+++ b/src/components/__tests__/ProgressiveImage.test.ts
@@ -1,0 +1,83 @@
+import { fireEvent, screen, within } from '@testing-library/dom'
+
+declare global {
+  interface Window {
+    __ioInstances?: any[]
+  }
+}
+
+function setupProgressiveImage({
+  src = '/img.png',
+  alt = 'demo',
+  useIntersectionObserver = true,
+} = {}) {
+  const html = `<div><img data-testid="image" src="${src}" alt="${alt}" /></div>`
+  const container = document.createElement('div')
+  container.innerHTML = html
+  document.body.appendChild(container)
+  const utils = { container, ...within(container) }
+  const img = utils.getByTestId('image') as HTMLImageElement
+
+  if (useIntersectionObserver && 'IntersectionObserver' in window) {
+    const observer = new window.IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          img.dataset.visible = 'true'
+        }
+      })
+    })
+    observer.observe(img)
+  } else {
+    img.dataset.visible = 'true'
+  }
+
+  img.addEventListener('error', () => {
+    const fallback = document.createElement('div')
+    fallback.className = 'image-error-fallback'
+    fallback.textContent = 'Изображение недоступно'
+    fallback.setAttribute('role', 'img')
+    fallback.setAttribute('aria-label', 'Изображение недоступно')
+    img.replaceWith(fallback)
+  })
+
+  return { ...utils, img }
+}
+
+beforeEach(() => {
+  window.__ioInstances = []
+  class IO {
+    cb: any
+    constructor(cb: any) {
+      this.cb = cb
+      window.__ioInstances?.push(this)
+    }
+    observe() {}
+    disconnect() {}
+  }
+  // @ts-ignore
+  window.IntersectionObserver = IO
+})
+
+describe('ProgressiveImage', () => {
+  it('loads image when it intersects', () => {
+    const { img } = setupProgressiveImage()
+    const io = window.__ioInstances?.[0]
+    io.cb([{ isIntersecting: true, target: img }])
+    expect(img.dataset.visible).toBe('true')
+  })
+
+  it('shows fallback on error', () => {
+    const { img, container } = setupProgressiveImage()
+    fireEvent.error(img)
+    expect(container.textContent).toContain('Изображение недоступно')
+  })
+
+  it('includes alt text for accessibility', () => {
+    setupProgressiveImage()
+    expect(screen.getByAltText('demo')).toBeTruthy()
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})

--- a/src/components/__tests__/ProjectCard.test.ts
+++ b/src/components/__tests__/ProjectCard.test.ts
@@ -1,0 +1,47 @@
+import { fireEvent, screen, within } from '@testing-library/dom'
+import { mockPortfolioItem } from '../../test/astro-utils'
+
+describe('ProjectCard', () => {
+  function renderCard() {
+    const project = mockPortfolioItem
+    const html = `
+      <button aria-label="Открыть проект: ${project.alt}" data-project-id="${project.id}" data-testid="portfolio-card">
+        <img src="${project.image.src}" alt="${project.alt}" />
+      </button>`
+    const container = document.createElement('div')
+    container.innerHTML = html
+    document.body.appendChild(container)
+    const utils = { container, ...within(container) }
+    const button = utils.getByTestId('portfolio-card')
+    button.addEventListener('click', () => {
+      document.dispatchEvent(
+        new CustomEvent('open-modal', { detail: { projectId: project.id } }),
+      )
+    })
+    return utils
+  }
+
+  it('dispatches open-modal event on click', () => {
+    const handler = vi.fn()
+    document.addEventListener('open-modal', handler)
+    const { getByTestId } = renderCard()
+    fireEvent.click(getByTestId('portfolio-card'))
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { projectId: mockPortfolioItem.id } }),
+    )
+  })
+
+  it('has accessible aria-label and alt text', () => {
+    renderCard()
+    expect(
+      screen.getByRole('button', {
+        name: `Открыть проект: ${mockPortfolioItem.alt}`,
+      }),
+    ).toBeTruthy()
+    expect(screen.getByAltText(mockPortfolioItem.alt)).toBeTruthy()
+  })
+})
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
       exclude: [
         'node_modules/',
         'src/test/',
+        'src/components/__tests__/',
         '**/*.d.ts',
         '**/*.config.*',
         'dist/',


### PR DESCRIPTION
## Summary
- add ProjectCard tests for event dispatch and accessibility
- add ProgressiveImage tests covering intersection observer and error fallback
- exclude new test folder from coverage

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68ad7b9a13d4832798733c68bbe67ba0