### PR TITLE
fix: resolve lint errors

### DIFF
--- a/src/components/ProgressiveImage.astro
+++ b/src/components/ProgressiveImage.astro
@@ -2,6 +2,7 @@
 import { Image } from 'astro:assets'
 import type { ImageMetadata } from 'astro'
 import SkeletonLoader from './ui/SkeletonLoader.astro'
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import progressiveImage from '../controllers/progressiveImage'
 
 interface Props {

--- a/src/controllers/changeSlide.ts
+++ b/src/controllers/changeSlide.ts
@@ -1,4 +1,6 @@
-export async function changeSlide(controller: any, newIndex: number) {
+import type { ModalController } from './modalController'
+
+export async function changeSlide(controller: ModalController, newIndex: number) {
   if (
     controller.isTransitioning ||
     !controller.currentProject ||

--- a/src/controllers/eventSubscriptions.ts
+++ b/src/controllers/eventSubscriptions.ts
@@ -1,4 +1,6 @@
-export function subscribeToModalEvents(controller: any) {
+import type { ModalController } from './modalController'
+
+export function subscribeToModalEvents(controller: ModalController) {
   document.addEventListener('open-modal', (e: Event) => {
     const ce = e as CustomEvent<{ projectId?: string }>
     if (ce.detail?.projectId) {

--- a/src/controllers/modalController.ts
+++ b/src/controllers/modalController.ts
@@ -136,3 +136,5 @@ export default function createModalController() {
     },
   }
 }
+
+export type ModalController = ReturnType<typeof createModalController>

--- a/src/controllers/openModal.ts
+++ b/src/controllers/openModal.ts
@@ -1,6 +1,9 @@
-import type { RuntimeProject } from './modalController'
+import type { ModalController, RuntimeProject } from './modalController'
 
-export async function openModal(controller: any, projectId: string) {
+export async function openModal(
+  controller: ModalController,
+  projectId: string,
+) {
   if (controller.isModalOpen) return
 
   const projects = (window as Window & { portfolioProjects?: RuntimeProject[] })

--- a/src/test/modalController.test.ts
+++ b/src/test/modalController.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest'
 import createModalController from '../controllers/modalController'
+import type { RuntimeProject } from '../controllers/modalController'
 import { subscribeToModalEvents } from '../controllers/eventSubscriptions'
 
 describe('ModalController', () => {
@@ -46,7 +47,7 @@ describe('ModalController', () => {
   it('openModal loads project data', async () => {
     const controller = createModalController()
     controller.preloadImage = vi.fn().mockResolvedValue(new Image())
-    ;(window as any).portfolioProjects = [
+    ;(window as Window & { portfolioProjects: RuntimeProject[] }).portfolioProjects = [
       {
         id: '1',
         title: 'Test',

--- a/src/test/progressiveImageController.test.ts
+++ b/src/test/progressiveImageController.test.ts
@@ -31,7 +31,7 @@ describe('progressiveImage controller', () => {
 
   beforeEach(() => {
     // clean up any global errorHandler
-    // @ts-ignore
+    // @ts-expect-error: remove test handler if it exists
     delete window.errorHandler
   })
 


### PR DESCRIPTION
## Summary
- type modal controllers to avoid `any`
- handle global error handler cleanup with `@ts-expect-error`
- suppress unused import warning in `ProgressiveImage` component

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ada23212b88327a9560965ddfd1ce7