### PR TITLE
refactor: centralize delay util and streamline slide change

### DIFF
--- a/src/controllers/changeSlide.ts
+++ b/src/controllers/changeSlide.ts
@@ -1,4 +1,5 @@
 import type { ModalController } from './modalController'
+import { delay } from '../utils/delay'
 
 export async function changeSlide(
   controller: ModalController,
@@ -14,37 +15,29 @@ export async function changeSlide(
   controller.isTransitioning = true
   controller.isContentVisible = false
 
-  await new Promise((resolve) => setTimeout(resolve, 150))
+  await delay(150)
 
+  let imageLoaded = false
   const skeletonTimeout = window.setTimeout(() => {
     if (!imageLoaded) {
       controller.isImageLoading = true
     }
   }, 150)
-  let imageLoaded = false
 
   try {
     const newSlide = controller.currentProject.slides[newIndex]
     if (newSlide?.image?.src) {
       await controller.preloadImage(newSlide.image.src)
     }
-
-    imageLoaded = true
-    clearTimeout(skeletonTimeout)
-
-    controller.isImageLoading = false
-    controller.currentSlideIndex = newIndex
-    controller.isContentVisible = true
-
-    await new Promise((resolve) => setTimeout(resolve, 150))
   } catch {
+    // ignore preload errors
+  } finally {
     imageLoaded = true
     clearTimeout(skeletonTimeout)
     controller.isImageLoading = false
     controller.currentSlideIndex = newIndex
     controller.isContentVisible = true
-    await new Promise((resolve) => setTimeout(resolve, 150))
+    await delay(150)
+    controller.isTransitioning = false
   }
-
-  controller.isTransitioning = false
 }

--- a/src/utils/delay.ts
+++ b/src/utils/delay.ts
@@ -1,0 +1,3 @@
+export function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
## Summary
- extract reusable delay helper
- simplify slide change controller using new helper and try/finally cleanup

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adbf94225083278b46137357b3b3f0