### PR TITLE
refactor(modal): separate UI helpers and tighten store slide logic

### DIFF
--- a/src/components/__tests__/Modal.test.ts
+++ b/src/components/__tests__/Modal.test.ts
@@ -14,7 +14,9 @@ describe('Modal component', () => {
     const doc = parseAstroHTML(html)
     const dialog = doc.querySelector('div[role="dialog"]')
     expect(dialog).toBeTruthy()
-    expect(dialog?.getAttribute('x-on:click.self')).toContain('unlockBodyScroll')
+    expect(dialog?.getAttribute('x-on:click.self')).toContain(
+      'unlockBodyScroll',
+    )
     const close = doc.querySelector('button[aria-label="Закрыть"]')
     expect(close).toBeTruthy()
     expect(close?.getAttribute('x-on:click')).toContain('unlockBodyScroll')

--- a/src/controllers/__tests__/modal-store.test.ts
+++ b/src/controllers/__tests__/modal-store.test.ts
@@ -102,6 +102,23 @@ describe('ModalStore', () => {
     expect(store.changeSlide).toHaveBeenCalledWith(2)
   })
 
+  it('goToSlide ignores out-of-range indices', () => {
+    const store = new ModalStore()
+    store.currentProject = {
+      id: '1',
+      title: 'Test',
+      description: '',
+      audience: '',
+      slides: [{}, {}],
+    }
+    store.changeSlide = vi.fn()
+
+    store.goToSlide(-1)
+    store.goToSlide(5)
+
+    expect(store.changeSlide).not.toHaveBeenCalled()
+  })
+
   it('returns the current slide', () => {
     const store = new ModalStore()
     store.currentProject = {

--- a/src/controllers/modal-store.ts
+++ b/src/controllers/modal-store.ts
@@ -1,5 +1,9 @@
 export type RuntimeImage = { src?: string; width?: number; height?: number }
-export type RuntimeSlide = { image?: RuntimeImage; task?: string; solution?: string }
+export type RuntimeSlide = {
+  image?: RuntimeImage
+  task?: string
+  solution?: string
+}
 export type RuntimeProject = {
   id: string
   title: string
@@ -55,12 +59,11 @@ export class ModalStore {
   }
 
   goToSlide(index: number) {
-    if (
-      !this.currentProject ||
-      !this.currentProject.slides ||
-      index === this.currentSlideIndex
-    )
+    if (!this.currentProject || !this.currentProject.slides) return
+    const totalSlides = this.currentProject.slides.length
+    if (index < 0 || index >= totalSlides || index === this.currentSlideIndex) {
       return
+    }
     this.changeSlide(index)
   }
 

--- a/src/controllers/modal-ui.ts
+++ b/src/controllers/modal-ui.ts
@@ -1,15 +1,15 @@
-export function initModalUI(nextTick: (cb: () => void) => void) {
-  const isTouchDevice =
-    'ontouchstart' in window || navigator.maxTouchPoints > 0
+export function updateCloseHint() {
+  const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+  const hintElement = document.getElementById('close-hint')
+  if (hintElement) {
+    hintElement.textContent = isTouchDevice
+      ? 'тап для закрытия'
+      : 'ESC или клик для закрытия'
+  }
+}
 
-  nextTick(() => {
-    const hintElement = document.getElementById('close-hint')
-    if (hintElement) {
-      hintElement.textContent = isTouchDevice
-        ? 'тап для закрытия'
-        : 'ESC или клик для закрытия'
-    }
-  })
+export function initModalUI(nextTick: (cb: () => void) => void) {
+  nextTick(updateCloseHint)
 }
 
 export function lockBodyScroll() {


### PR DESCRIPTION
## Summary
- extract `updateCloseHint` helper into dedicated modal UI module
- guard `goToSlide` against out-of-range indices in `ModalStore`
- expand ModalStore tests for invalid slide navigation

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af15db99088327a7cc220493702162