### PR TITLE
refactor(modal): move projects to Alpine store

### DIFF
--- a/src/controllers/openModal.ts
+++ b/src/controllers/openModal.ts
@@ -2,14 +2,15 @@ import type { ModalController } from './modalController'
 import type { RuntimeProject } from './modal-store'
 import { lockBodyScroll } from './modal-ui'
 
+/* global Alpine */
+
 export async function openModal(
   controller: ModalController,
   projectId: string,
 ) {
   if (controller.isModalOpen) return
 
-  const projects = (window as Window & { portfolioProjects?: RuntimeProject[] })
-    .portfolioProjects
+  const projects = Alpine.store('projects') as RuntimeProject[] | undefined
   if (!projects) return
 
   const project = projects.find((p) => p.id === projectId)

--- a/src/controllers/projectsStore.ts
+++ b/src/controllers/projectsStore.ts
@@ -1,0 +1,7 @@
+import { projects } from '../data/projects'
+
+/* global Alpine */
+
+document.addEventListener('alpine:init', () => {
+  Alpine.store('projects', JSON.parse(JSON.stringify(projects)))
+})

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -5,15 +5,11 @@ import PortfolioSection from '../components/PortfolioSection.astro'
 import ContactSection from '../components/ContactSection.astro'
 import Footer from '../components/Footer.astro'
 import Modal from '../components/Modal.astro'
-import { projects } from '../data/projects'
 ---
 
-<script is:inline define:vars={{ projects }}>
-  // Ensure proper UTF-8 encoding for projects data
-  window.portfolioProjects = JSON.parse(JSON.stringify(projects))
-</script>
 <script>
   import createModalController from '../controllers/modalController'
+  import '../controllers/projectsStore'
   /* global Alpine */
   document.addEventListener('alpine:init', () => {
     Alpine.data('modalController', createModalController)

--- a/src/test/modalController.test.ts
+++ b/src/test/modalController.test.ts
@@ -49,17 +49,24 @@ describe('ModalController', () => {
   it('openModal loads project data', async () => {
     const controller = createModalController()
     controller.preloadImage = vi.fn().mockResolvedValue(new Image())
-    ;(
-      window as Window & { portfolioProjects: RuntimeProject[] }
-    ).portfolioProjects = [
-      {
-        id: '1',
-        title: 'Test',
-        description: '',
-        audience: '',
-        slides: [{ image: { src: 'img.jpg' } }],
-      },
-    ]
+    ;(globalThis as typeof globalThis & {
+      Alpine: { store: (name: string) => RuntimeProject[] }
+    }).Alpine = {
+      store: vi.fn().mockImplementation((name: string) => {
+        if (name === 'projects') {
+          return [
+            {
+              id: '1',
+              title: 'Test',
+              description: '',
+              audience: '',
+              slides: [{ image: { src: 'img.jpg' } }],
+            },
+          ]
+        }
+        return []
+      }),
+    }
 
     await controller.openModal('1')
 


### PR DESCRIPTION
## Summary
- register projects data in Alpine store
- load projects from Alpine store when opening modal
- replace window-based project wiring with store registration

## Testing
- `npm test -- --run`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af27f19998832798ca1125a42ebd97