### PR TITLE
refactor(modal): derive RuntimeProject from Project type

### DIFF
--- a/src/controllers/modal-store.ts
+++ b/src/controllers/modal-store.ts
@@ -1,15 +1,10 @@
+import type { RuntimeProject } from './modalController'
+
 export type RuntimeImage = { src?: string; width?: number; height?: number }
 export type RuntimeSlide = {
   image?: RuntimeImage
   task?: string
   solution?: string
-}
-export type RuntimeProject = {
-  id: string
-  title: string
-  description: string
-  audience: string
-  slides: RuntimeSlide[]
 }
 
 export class ModalStore {

--- a/src/controllers/modalController.ts
+++ b/src/controllers/modalController.ts
@@ -3,6 +3,10 @@ import { changeSlide } from './changeSlide'
 import { subscribeToModalEvents } from './eventSubscriptions'
 import { ModalStore } from './modal-store'
 import { initModalUI } from './modal-ui'
+import type { RuntimeSlide } from './modal-store'
+import type { Project } from '../types'
+
+export type RuntimeProject = Omit<Project, 'slides'> & { slides: RuntimeSlide[] }
 
 export default function createModalController() {
   const store = new ModalStore()

--- a/src/controllers/openModal.ts
+++ b/src/controllers/openModal.ts
@@ -1,5 +1,4 @@
-import type { ModalController } from './modalController'
-import type { RuntimeProject } from './modal-store'
+import type { ModalController, RuntimeProject } from './modalController'
 import { lockBodyScroll } from './modal-ui'
 
 /* global Alpine */

--- a/src/test/modalController.test.ts
+++ b/src/test/modalController.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
-import createModalController from '../controllers/modalController'
-import type { RuntimeProject } from '../controllers/modal-store'
+import createModalController, {
+  RuntimeProject,
+} from '../controllers/modalController'
 import { subscribeToModalEvents } from '../controllers/eventSubscriptions'
 
 describe('ModalController', () => {


### PR DESCRIPTION
## Summary
- derive `RuntimeProject` from `Project` and expose it via modal controller
- update modal store, open modal handler, and tests to import the new type

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af3fb052e08327a324f1b9de77ca14