### PR TITLE
refactor: centralize open modal event

### DIFF
--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from 'astro:assets'
 import type { PortfolioItem } from '../types'
+import { OPEN_MODAL_EVENT } from '../utils/events'
 import '../styles/components/project-card.css'
 
 interface Props {
@@ -19,8 +20,8 @@ const { project, index = 0 } = Astro.props
   data-project-id={project.id}
   x-data={`{
     handleClick() {
-      document.dispatchEvent(new CustomEvent('open-modal', { 
-        detail: { projectId: '${project.id}' } 
+      document.dispatchEvent(new CustomEvent('${OPEN_MODAL_EVENT}', {
+        detail: { projectId: '${project.id}' }
       }));
     }
   }`}

--- a/src/components/__tests__/ProjectCard.test.ts
+++ b/src/components/__tests__/ProjectCard.test.ts
@@ -1,5 +1,6 @@
 import { fireEvent, screen, within } from '@testing-library/dom'
 import { mockPortfolioItem } from '../../test/astro-utils'
+import { OPEN_MODAL_EVENT } from '../../utils/events'
 
 describe('ProjectCard', () => {
   function renderCard() {
@@ -15,7 +16,9 @@ describe('ProjectCard', () => {
     const button = utils.getByTestId('portfolio-card')
     button.addEventListener('click', () => {
       document.dispatchEvent(
-        new CustomEvent('open-modal', { detail: { projectId: project.id } }),
+        new CustomEvent(OPEN_MODAL_EVENT, {
+          detail: { projectId: project.id },
+        }),
       )
     })
     return utils
@@ -23,7 +26,7 @@ describe('ProjectCard', () => {
 
   it('dispatches open-modal event on click', () => {
     const handler = vi.fn()
-    document.addEventListener('open-modal', handler)
+    document.addEventListener(OPEN_MODAL_EVENT, handler)
     const { getByTestId } = renderCard()
     fireEvent.click(getByTestId('portfolio-card'))
     expect(handler).toHaveBeenCalledWith(

--- a/src/controllers/eventSubscriptions.ts
+++ b/src/controllers/eventSubscriptions.ts
@@ -1,8 +1,9 @@
 import type { ModalController } from './modalController'
 import { unlockBodyScroll } from './modal-ui'
+import { OPEN_MODAL_EVENT } from '../utils/events'
 
 export function subscribeToModalEvents(controller: ModalController) {
-  document.addEventListener('open-modal', (e: Event) => {
+  document.addEventListener(OPEN_MODAL_EVENT, (e: Event) => {
     const ce = e as CustomEvent<{ projectId?: string }>
     if (ce.detail?.projectId) {
       controller.openModal(ce.detail.projectId)

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { projects } from '../data/projects'
 import { portfolioData } from '../data/portfolio'
+import { OPEN_MODAL_EVENT } from '../utils/events'
 
 describe('Integration Tests', () => {
   describe('Данные портфолио и проекты', () => {
@@ -96,17 +97,17 @@ describe('Integration Tests', () => {
       const mockHandler = vi.fn()
 
       // Регистрируем обработчик
-      document.addEventListener('open-modal', mockHandler)
+      document.addEventListener(OPEN_MODAL_EVENT, mockHandler)
 
       // Диспатчим событие
-      const event = new CustomEvent('open-modal', {
+      const event = new CustomEvent(OPEN_MODAL_EVENT, {
         detail: { projectId: 'project1' },
       })
       document.dispatchEvent(event)
 
       expect(mockHandler).toHaveBeenCalledWith(
         expect.objectContaining({
-          type: 'open-modal',
+          type: OPEN_MODAL_EVENT,
           detail: { projectId: 'project1' },
         }),
       )

--- a/src/test/modalController.test.ts
+++ b/src/test/modalController.test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, vi } from 'vitest'
-import createModalController, {
-  RuntimeProject,
-} from '../controllers/modalController'
+import createModalController, { RuntimeProject } from '../controllers/modalController'
 import { subscribeToModalEvents } from '../controllers/eventSubscriptions'
+import { OPEN_MODAL_EVENT } from '../utils/events'
 
 describe('ModalController', () => {
   it('resets state on closeModal', () => {
@@ -109,7 +108,7 @@ describe('ModalController', () => {
     subscribeToModalEvents(controller)
 
     document.dispatchEvent(
-      new CustomEvent('open-modal', { detail: { projectId: '1' } }),
+      new CustomEvent(OPEN_MODAL_EVENT, { detail: { projectId: '1' } }),
     )
     expect(controller.openModal).toHaveBeenCalledWith('1')
 

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,1 @@
+export const OPEN_MODAL_EVENT = 'open-modal'


### PR DESCRIPTION
## Summary
- introduce `OPEN_MODAL_EVENT` utility constant
- use constant in `ProjectCard` component and modal event subscriptions
- update tests to reference the shared event name

## Testing
- `npm test`
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af47278a2c8327bba02dbc6c4a8765